### PR TITLE
Add APM solution section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ An awesome list that curates the best Egg.js plugins, tools, tutorials, articles
 - [Applications](#applications)
 - [Boilerplates](#boilerplates)
 - [Frameworks](#frameworks)
+- [APM Solution](#apm-solution)
 
 Many thanks to everyone on the [contributor list](https://github.com/eggjs/awesome-egg/graphs/contributors) :)
 
@@ -113,3 +114,7 @@ Many thanks to everyone on the [contributor list](https://github.com/eggjs/aweso
 - [aliyun-egg](https://github.com/eggjs/aliyun-egg) - node web framework for aliyun, base on eggjs
 - [avet](https://github.com/avetjs/avet) - A very comfortable framework for writing isomorphic applications
 - [EggBorn.js](https://github.com/zhennann/egg-born) - The Ultimate Javascript Full Stack Framework
+
+## APM Solution
+
+- [Skywalking Node.js](https://github.com/OpenSkywalking/skywalking-nodejs) - Apache SkyWalking(incubator) provides an APM solution for Node.js server application


### PR DESCRIPTION
[Skywalking Node.js](https://github.com/OpenSkywalking/skywalking-nodejs) 0.3.1 had support tracing egg framework and here is the [screen snapshot](https://www.oschina.net/news/99456/skywalking-support-egg-framework),  So I send the PR that adding the `APM solution` section to introduce how to tracing the egg framework.