### PR TITLE
Add plugin for egg

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Many thanks to everyone on the [contributor list](https://github.com/eggjs/aweso
 - [egg-weapp-sdk](https://github.com/seasonstar/egg-weapp-sdk) - Egg的微信小程序登录会话管理SDK
 - [egg-wechat-api](https://github.com/thonatos/egg-wechat-api) - WechatApi for egg
 - [egg-zookeeper](https://github.com/eggjs/egg-zookeeper) - zookeeper plugin for egg
+- [egg-hashids](https://github.com/weihongyu12/egg-hashids) - generate a short unique ID from the integer for eg
 
 ## Applications
 


### PR DESCRIPTION
Add a new plugin `egg-hashids` for egg.

Hashids is small JavaScript library to generate YouTube-like ids from numbers. Use it when you don't want to expose your database ids to the user.